### PR TITLE
Fix built‑in profile handling

### DIFF
--- a/bhima_scan.py
+++ b/bhima_scan.py
@@ -9,7 +9,7 @@ import os
 import json
 import requests
 
-from bhima_scan.cli import parse_arguments
+from bhima_scan.cli import parse_arguments, PROFILES
 from bhima_scan.interactive import interactive_config, load_saved_profiles
 from bhima_scan.core import BhimaScan
 
@@ -79,6 +79,15 @@ def main():
         args.username   = cfg.get('username')
         args.password   = cfg.get('password')
         args.oob_domain = cfg.get('oob_domain')
+
+    # Apply built-in profile defaults
+    profile_defaults = PROFILES.get(args.profile or 'basic', {})
+    if args.threads is None:
+        args.threads = profile_defaults.get('threads', PROFILES['basic']['threads'])
+    if args.status is None:
+        args.status = profile_defaults.get('status', PROFILES['basic']['status'])
+    if args.format is None:
+        args.format = profile_defaults.get('format', PROFILES['basic']['format'])
 
     # Ensure URL is provided
     if not args.url:

--- a/bhima_scan/interactive.py
+++ b/bhima_scan/interactive.py
@@ -97,6 +97,14 @@ def interactive_config():
     px = input(Fore.WHITE + f"Proxy URL [{defaults['proxy']}]: " + Style.RESET_ALL).strip() or defaults['proxy']
     pr = input(Fore.WHITE + f"Profile [{defaults['profile']}]: " + Style.RESET_ALL).strip()
     profile = pr if pr in PROFILES else defaults['profile']
+    if profile:
+        prof = PROFILES[profile]
+        if not th:
+            threads = prof['threads']
+        if st == defaults['status']:
+            st = prof['status']
+        if fmt == defaults['format']:
+            fmt = prof['format']
     bp = input(Fore.WHITE + "Enable 403-bypass mode? [y/N]: " + Style.RESET_ALL).strip().lower()
     bypass_403 = bp in ('y','yes')
     lu = input(Fore.WHITE + f"Login URL [{defaults['login_url']}]: " + Style.RESET_ALL).strip() or defaults['login_url']


### PR DESCRIPTION
## Summary
- import profiles in the main launcher
- apply profile defaults in main when thread count or other settings unset
- respect selected profile in interactive setup

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68409384124c8323ad401c2a8cf34174